### PR TITLE
Use GCC when compiling on Linux so we can use C++20

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -22,16 +22,16 @@ jobs:
             platform: linux
             artifact-name: gdtiltfive.linux
             artifact-path: |
-              build/bin/libTiltFiveGodot.*
-              extension/TiltFiveNDK/lib/linux/TiltFiveNative.so
+              build/bin/linux/libTiltFiveGodot.*
+              TiltFiveNDK/lib/linux/x86_64/TiltFiveNative.so
 
           - name: 🏁 Windows (x86_64, MSVC)
             os: windows-2019
             platform: windows
             artifact-name: gdtiltfive.windows
             artifact-path: |
-              build/bin/TiltFiveGodot.dll
-              extension/TiltFiveNDK/lib/win64/TiltFiveNative.dll
+              build/bin/windows/TiltFiveGodot.dll
+              TiltFiveNDK/lib/win/x86_64/TiltFiveNative.dll
 
           #- name: 🍎 macOS (universal)
           #  os: macos-11
@@ -71,7 +71,7 @@ jobs:
         if: ${{ matrix.platform == 'linux' }}
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -qqq build-essential pkg-config
+          sudo apt-get install -qqq build-essential pkg-config gcc-11 g++-11
 
       - name: Install scons
         run: |
@@ -85,7 +85,7 @@ jobs:
 
       - name: Build release build
         run: |
-          scons platform=${{ matrix.platform }} target=release custom_api_file=patches/extension_api.json ${{ matrix.flags }}
+          scons platform=${{ matrix.platform }} target=release ${{ matrix.flags }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -120,11 +120,11 @@ jobs:
           cp source/CONTRIBUTORS.md plugin/addons/tiltfive
           cp source/CHANGES.md plugin/addons/tiltfive
           mkdir plugin/addons/tiltfive/linux
-          cp gdtiltfive.linux/*.so plugin/addons/tiltfive/linux/
-          cp gdtiltfive.linux/extension/TiltFiveNDK/lib/linux/TiltFiveNative.so plugin/addons/tiltfive/linux/
+          cp gdtiltfive.linux/build/bin/linux/*.so plugin/addons/tiltfive/linux/
+          cp gdtiltfive.linux/TiltFiveNDK/lib/linux/TiltFiveNative.so plugin/addons/tiltfive/linux/
           mkdir plugin/addons/tiltfive/windows
-          cp gdtiltfive.windows/build/bin/*.dll plugin/addons/tiltfive/windows/
-          cp gdtiltfive.windows/extension/TiltFiveNDK/lib/win64/*.dll plugin/addons/tiltfive/windows/
+          cp gdtiltfive.windows/build/bin/windows/*.dll plugin/addons/tiltfive/windows/
+          cp gdtiltfive.windowsTiltFiveNDK/lib/win/x86_64/*.dll plugin/addons/tiltfive/windows/
           # cp gdtiltfive.android/*.so plugin/addons/tiltfive/android/
           # cp gdtiltfive.ios/*.dylib plugin/addons/tiltfive/ios/
           # cp -R gdtiltfive.macos/libgdtiltfive.macos.* plugin/addons/tiltfive/macos/

--- a/SConstruct
+++ b/SConstruct
@@ -9,7 +9,7 @@ VariantDir("build/src","src", duplicate=False)
 VariantDir("build/T5Integration","T5Integration", duplicate=False)
 
 # Gets the standard flags CC, CCX, etc.
-env = DefaultEnvironment()
+env = Environment(ENV = os.environ)
 
 #scons_compiledb.enable_with_cmdline(env)
 
@@ -27,16 +27,18 @@ bits = 64
 # Updates the environment with the option variables.
 opts.Update(env)
 
-# Process some arguments
-if env['use_llvm']:
-    env['CC'] = 'clang'
-    env['CXX'] = 'clang++'
-
 if env['p'] != '':
     env['platform'] = env['p']
 
 if env['platform'] == '':
     env['platform'] = 'windows'
+
+if env['use_llvm']:
+    env['CC'] = 'clang'
+    env['CXX'] = 'clang++'
+elif env['platform'] == 'linux':
+    env['CC'] = 'gcc-11'
+    env['CXX'] = 'g++-11'
 
 env['target'] =  { 'd' : 'debug', 'debug' : 'debug', 'r' : 'release', 'release' : "release"}[env["target"]]
 env['platform_dir'] = { 'windows' : 'win', 'linux' : 'linux', 'osx' : 'osx'}[env["platform"]]
@@ -82,6 +84,7 @@ if env['platform'] == "windows":
     env['t5_shared_lib'] = 'TiltFiveNative'
     env['t5_shared_link_lib'] = 'TiltFiveNative.dll.if'
     env['target_name'] = 'TiltFiveGodot'
+
     # This makes sure to keep the session environment variables on windows,
     # that way you can run scons in a vs 2017 prompt and it will find all the required tools
     env.Append(ENV=os.environ)
@@ -103,7 +106,7 @@ elif env['platform'] in ('x11', 'linux'):
     env['t5_shared_link_lib'] = 'libTiltFiveNative'
     env['target_name'] = 'libTiltFiveGodot'
     env.Append(CCFLAGS=['-fPIC'])
-    env.Append(CXXFLAGS=['-std=c++2b'])
+    env.Append(CXXFLAGS=['-std=c++20'])
     env.Append(RPATH=env.Literal('\\$$ORIGIN' ))
     if env['target'] in ('debug', 'd'):
         env.Append(CCFLAGS=['-g3', '-Og'])


### PR DESCRIPTION
Changes from @patrickdown , use GCC to build plugin on linux.